### PR TITLE
Update plugins.sh required version regexp

### DIFF
--- a/sonarqube/plugins.sh
+++ b/sonarqube/plugins.sh
@@ -15,7 +15,7 @@ printf "Downloading additional plugins\n"
 for PLUGIN in "$@"
 do
 	printf '\tExtracting plugin download location - %s\n' ${PLUGIN}
-	MATCH_STRING=$(cat /tmp/pluginList.txt | grep requiredSonarVersions | grep "${SQ_VERSION}" | sed 's@\.requiredSonarVersions.*@@g' | sort -V | grep "^${PLUGIN}\." | tail -n 1 | sed 's@$@.downloadUrl@g')
+	MATCH_STRING=$(cat /tmp/pluginList.txt | grep requiredSonarVersions | grep -E "[,=]${SQ_VERSION}(,|$)" | sed 's@\.requiredSonarVersions.*@@g' | sort -V | grep "^${PLUGIN}\." | tail -n 1 | sed 's@$@.downloadUrl@g')
 
 	if ! [[ -z "${MATCH_STRING}" ]]; then
 		DOWNLOAD_URL=$(cat /tmp/pluginList.txt | grep ${MATCH_STRING} | awk -F"=" '{print $2}' | sed 's@\\:@:@g')


### PR DESCRIPTION
#### What is this PR About?
Plugin versions were matching on partial version strings... e.g. "7.7" ~ "6.7.7".  This pull request alters the regexp to prevent this partial match.

#### How do we test this?

1. Rebuild the image.
2. Optionally test the new regexp on regexp101.com
3. Validate the list of selected plugins against https://update.sonarsource.org/update-center.properties

cc: @redhat-cop/day-in-the-life
